### PR TITLE
Change /media volume to /music

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,10 +84,10 @@ RUN a2enmod rewrite
 COPY --from=front-builder --chown=www-data:www-data /tmp/koel /var/www/html
 
 # Music volume
-VOLUME ["/media"]
+VOLUME ["/music"]
 
 ENV FFMEPG_PATH=/usr/bin/ffmpeg \
-    MEDIA_PATH=/media \
+    MEDIA_PATH=/music \
     STREAMING_METHOD=x-sendfile
 
 # Setup bootstrap script.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ docker run -d --name koel --env-file .koel.env -p 80:80 hyzual/koel
 
 ### Scan media folders
 
-Whenever the music in `/media` changes, you will need to manually scan it before
+Whenever the music in `/music` changes, you will need to manually scan it before
 koel is able to play it. Run the following command:
 
 ```bash
@@ -104,9 +104,9 @@ See [`.env.example`][koel-env-example] for reference.
 
 ## Volumes
 
-### /media
+### /music
 
-`/media` will contain the music library. Keep in mind that koel needs to
+`/music` will contain the music library. Keep in mind that koel needs to
 scan music before it's able to play it.
 
 ## Ports

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,7 +17,7 @@ services:
       - DB_DATABASE=koel
       - DB_USERNAME=koel
     volumes:
-      - music:/media
+      - music:/music
       - covers:/var/www/html/public/img/covers
       - ./.env.koel:/var/www/html/.env
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '3.7'
 
 services:
   koel:
@@ -14,7 +14,7 @@ services:
       DB_PASSWORD: koel
       DB_DATABASE: koel
     volumes:
-      - music:/media
+      - music:/music
       - covers:/var/www/html/public/img/covers
 
   database:
@@ -30,9 +30,7 @@ services:
 volumes:
   db:
     driver: local
-
   music:
     driver: local
-
   covers:
     driver: local

--- a/goss.yaml
+++ b/goss.yaml
@@ -7,7 +7,7 @@ file:
     filetype: file
     contains:
       - APP_KEY
-  /media:
+  /music:
     exists: true
     mode: "0755"
     owner: root


### PR DESCRIPTION
/media is reserved in the Filesystem Hierarchy Standard (see [0]) to
mount removable media, such as USB drives and CDs.
We should not mount to it, or some unexpected things might happen.
Instead, we can use /music which is not reserved in the FHS.

How to test:
  - docker-compose -f docker-compose.dev.yml up -d --build
  - dgoss run docker-koel_koel:latest

[0]: https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard