### PR TITLE
Fix typo to FFMPEG_PATH that was blocking FLAC transcoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ COPY --from=front-builder --chown=www-data:www-data /tmp/koel /var/www/html
 # Music volume
 VOLUME ["/music"]
 
-ENV FFMEPG_PATH=/usr/bin/ffmpeg \
+ENV FFMPEG_PATH=/usr/bin/ffmpeg \
     MEDIA_PATH=/music \
     STREAMING_METHOD=x-sendfile
 


### PR DESCRIPTION
It turns out that when you pass the right env variables, things work
much better.
FLAC could not be transcoded without FFMPEG, hence the 500 errors
popping up when trying to play those files.