### PR TITLE
add `gd` php-ext to enable cover extraction from id3 metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,10 +68,14 @@ RUN apt-get update && \
     libzip-dev \
     zip \
     ffmpeg \
+    libpng-dev \
+    libjpeg62-turbo-dev \
+  && docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ \
   && docker-php-ext-install \
     zip \
     pdo_mysql \
     exif \
+    gd \
   && apt-get clean
 
 # Copy Apache configuration


### PR DESCRIPTION
Previous to that the cover extraction was not working for me.

This PR adds the `gd` extension, which is required by koel for the extraction of the covers.