### PR TITLE
Revert and fix commit 3198879

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,9 @@ COPY --from=php-builder /tmp/koel /tmp/koel
 # Install, build frontend assets and then delete the sources to save disk space
 RUN cd /tmp/koel/resources/assets && \
     # Skip cypress download and installation. It is not needed for a production image
-    CYPRESS_INSTALL_BINARY=0 yarn install --non-interactive && \
-    cd /tmp/koel/ && \
     yarn install --non-interactive && \
+    cd /tmp/koel/ && \
+    CYPRESS_INSTALL_BINARY=0 yarn install --non-interactive && \
     yarn run production && \
     rm -rf /tmp/koel/node_modules \
       /tmp/koel/resources/assets


### PR DESCRIPTION
Commit 3198879 prepended the `CYPRESS_INSTALL_BINARY=0` variable to
the install command in the ressources/assets directory, however
this component does not require cypress.

The root component however does. This environment variable should
be prepended to the second install command.

### PR #28 is based on this branch.