### PR TITLE
 Target multiple architectures (follow-up to #28)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -14,6 +14,8 @@ jobs:
           # Goss release version to install
           version: 'v0.3.13'
       - uses: actions/checkout@v2
+      - name: install buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
       - name: Build the Docker image
         run: make build-docker-image
       - name: Run goss tests

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,4 +1,3 @@
-
 name: Docker Image CI
 on:
   pull_request:
@@ -14,9 +13,11 @@ jobs:
           # Goss release version to install
           version: 'v0.3.13'
       - uses: actions/checkout@v2
+      - name: Build the x86_64 Docker image
+        run: make build-docker-image
+      - name: Run goss tests on x86_64 image
+        run: make dgoss-ci
       - name: install buildx
         uses: crazy-max/ghaction-docker-buildx@v1
-      - name: Build the Docker image
-        run: make build-docker-image
-      - name: Run goss tests
-        run: make dgoss-ci
+      - name: Build the Docker image for all supported architectures
+        run: make build-all-arch-docker-images

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Run tests
 on:
   pull_request:
   push:
@@ -11,13 +11,13 @@ jobs:
         uses: e1himself/goss-installation-action@v1
         with:
           # Goss release version to install
-          version: 'v0.3.13'
-      - uses: actions/checkout@v2
+          version: "v0.3.13"
+      - name: Checkout code
+        uses: actions/checkout@v2
       - name: Build the x86_64 Docker image
-        run: make build-docker-image
+        uses: docker/build-push-action@v1.1.0
+        with:
+          push: false
+          tags: hyzual/koel-dev:latest
       - name: Run goss tests on x86_64 image
         run: make dgoss-ci
-      - name: install buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
-      - name: Build the Docker image for all supported architectures
-        run: make build-all-arch-docker-images

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -18,6 +18,6 @@ jobs:
         uses: docker/build-push-action@v1.1.0
         with:
           push: false
-          tags: hyzual/koel-dev:latest
+          tags: latest
       - name: Run goss tests on x86_64 image
         run: make dgoss-ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
         uses: docker/build-push-action@v1.1.0
         with:
           push: false
-          tags: hyzual/koel:latest
+          tags: latest
       - name: Run goss tests on x86_64 image
         run: make dgoss-ci
       - name: Build and push production image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,13 +10,13 @@ jobs:
         uses: e1himself/goss-installation-action@v1
         with:
           # Goss release version to install
-          version: 'v0.3.11'
+          version: 'v0.3.13'
       - uses: actions/checkout@v2
-      - name: Build the Docker image
+      - name: Build the x86_64 Docker image
         run: make build-docker-image
-      - name: Run goss tests
-        run: dgoss run hyzual/koel-dev:latest
-      - name: make dgoss-ci
+      - name: Run goss tests on x86_64 image
+        run: make dgoss-ci
+      - name: Push the Docker image
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
           name: hyzual/koel

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Docker Hub publish
+name: Run tests and deploy image
 on:
   push:
     branches: [master]
@@ -10,15 +10,20 @@ jobs:
         uses: e1himself/goss-installation-action@v1
         with:
           # Goss release version to install
-          version: 'v0.3.13'
-      - uses: actions/checkout@v2
+          version: "v0.3.13"
+      - name: Checkout code
+        uses: actions/checkout@v2
       - name: Build the x86_64 Docker image
-        run: make build-docker-image
+        uses: docker/build-push-action@v1.1.0
+        with:
+          push: false
+          tags: hyzual/koel:latest
       - name: Run goss tests on x86_64 image
         run: make dgoss-ci
-      - name: Push the Docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+      - name: Build and push production image
+        uses: zmingxie/docker_buildx@v1.1
         with:
-          name: hyzual/koel
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          publish: true
+          imageName: hyzual/koel
+          dockerHubUser: ${{ secrets.DOCKER_HUB_USERNAME }}
+          dockerHubPassword: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -17,13 +17,15 @@ jobs:
         uses: docker/build-push-action@v1.1.0
         with:
           push: false
+          repository: hyzual/koel
           tags: latest
       - name: Run goss tests on x86_64 image
-        run: make dgoss-ci
+        run: dgoss run hyzual/koel:latest
       - name: Build and push production image
         uses: zmingxie/docker_buildx@v1.1
         with:
           publish: true
           imageName: hyzual/koel
+          tag: latest
           dockerHubUser: ${{ secrets.DOCKER_HUB_USERNAME }}
           dockerHubPassword: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
         uses: docker/build-push-action@v1.1.0
         with:
           push: false
-          tags: latest
+          repository: hyzual/koel
+          tags: test
       - name: Run goss tests on x86_64 image
-        run: make dgoss-ci
+        run: dgoss run hyzual/koel:test

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ COPY --from=php-builder /tmp/koel /tmp/koel
 # Install, build frontend assets and then delete the sources to save disk space
 RUN cd /tmp/koel/resources/assets && \
     # Skip cypress download and installation. It is not needed for a production image
-    yarn install --non-interactive && \
+    yarn install --non-interactive --network-timeout 100000 && \
     cd /tmp/koel/ && \
     CYPRESS_INSTALL_BINARY=0 yarn install --non-interactive && \
     yarn run production && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ FROM alpine:3.12.0 as front-builder
 
 # Add nodejs and yarn. bash and the other 8 deps are needed to build pngquant, which is a dev dependency for koel...
 RUN apk add --no-cache nodejs \
-    python3 bash lcms2-dev libpng-dev gcc g++ make autoconf automake \
+    python2 python3 bash lcms2-dev libpng-dev gcc g++ make autoconf automake \
     yarn
 
 # Copy sources from php builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,9 @@ COPY --from=php-builder /tmp/koel /tmp/koel
 # Install, build frontend assets and then delete the sources to save disk space
 RUN cd /tmp/koel/resources/assets && \
     # Skip cypress download and installation. It is not needed for a production image
-    CYPRESS_INSTALL_BINARY=0 yarn install --non-interactive && \
-    cd /tmp/koel/ && \
     yarn install --non-interactive && \
+    cd /tmp/koel/ && \
+    CYPRESS_INSTALL_BINARY=0 yarn install --non-interactive && \
     yarn run production && \
     rm -rf /tmp/koel/node_modules \
       /tmp/koel/resources/assets

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: build-docker-image
 
 build-docker-image: ## Builds the production Docker build-docker-image
-	docker build . --file Dockerfile --tag hyzual/koel-dev:latest
+	docker buildx build --platform linux/amd64,linux/arm/v7,linux/arm64 . --file Dockerfile --tag hyzual/koel-dev:latest
 
 dgoss-ci: ## Run goss tests on the production Docker image
 	dgoss run hyzual/koel-dev:latest

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
 
 all: build-docker-image
 
-build-docker-image: ## Builds the production Docker build-docker-image
+build-docker-image: ## Builds the production x86_64 Docker image
+	docker build . --file Dockerfile --tag hyzual/koel-dev:latest
+
+build-all-arch-docker-images: ## Builds the production Docker image for all supported processor architectures
 	docker buildx build --platform linux/amd64,linux/arm/v7,linux/arm64 . --file Dockerfile --tag hyzual/koel-dev:latest
 
 dgoss-ci: ## Run goss tests on the production Docker image


### PR DESCRIPTION
This is a follow-up to #28, I force-pushed to it... 🙄

# Description:
This PR makes the CI (GitHub Actions) build docker images working on not just x86_64, but also armv7 and arm64 (for example Raspberry Pis).

# Prerequisites:
This PR is based on #30. While you technically could just merge this one, I think it separates the commits into more logically complete units.

# Caveats:
It increases the buildtimes by a huge amount.
| x86_64 | x86_64 + armv7 + arm64 |
|--------|------------------------|
| ~ 6min |  ~ 1h 25min                    |

Build minutes on GitHub Actions [are free for public repos](https://github.com/features/actions#pricing-details) though, so I think this would be fine.

# See also:
Fixes issue #21.
Follow-up to PR #28.
PR #30 resolves problems with cypress.