### PR TITLE
merge some layers when copying the files into the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,9 +82,9 @@ COPY ./php.ini "$PHP_INI_DIR/php.ini"
 RUN a2enmod rewrite
 
 # Copy the downloaded release
-RUN cp -R /tmp/koel/. /var/www/html
-RUN [ ! -f /var/www/html/public/manifest.json ] && cp /var/www/html/public/manifest.json.example /var/www/html/public/manifest.json || true
-RUN chown -R www-data:www-data /var/www/html
+RUN cp -R /tmp/koel/. /var/www/html \
+  && mv /var/www/html/public/manifest.json.example /var/www/html/public/manifest.json \
+  && chown -R www-data:www-data /var/www/html
 
 # Create /tmp/koel if it doesn't exist, and set ownership to www-data
 RUN mkdir -p /tmp/koel \


### PR DESCRIPTION
merge some file layers so we don't make a layer just to change file ownership, just assign it the right permissions in the same layer

also simplify changing the manifest example into the actual manifest. we know for a fact it won't exist so no need to test for it. this also means that if for some reason there suddenly is a manifest, the build will fail and we can evaluate what the correct one is at that time, instead of it invisibly changing and potentially breaking