### PR TITLE
Fix graceful shutdown

### DIFF
--- a/koel-entrypoint
+++ b/koel-entrypoint
@@ -7,4 +7,4 @@ cd /var/www/html
 
 # Run the next entrypoint in the chain.
 echo "running docker-php-entrypoint with arguments $@"
-exec docker-php-entrypoint $@
+exec docker-php-entrypoint "$@"


### PR DESCRIPTION
## Problem
`docker compose down` takes 10 seconds and Docker forcefully kills the container because graceful shutdown doesn't work.

**Root cause:** The bash script in `koel-entrypoint` becomes PID 1, and doesn't forward signals (like SIGWINCH/SIGTERM) to the Apache child process. Docker waits for timeout, then sends SIGKILL.

## Solution
Use `exec` to replace bash with Apache as PID 1, so signals reach Apache directly.

Also quotes `"$@"` for proper argument handling (best practice).

## Result
Container now shuts down gracefully in 1-2 seconds instead of being killed after 10 seconds.