### PR TITLE
bump GitHub Actions versions off the deprecated Node 20 runtime

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -4,14 +4,17 @@ runs:
   using: 'composite'
   steps:
     - name: Install goss and dgoss
-      uses: e1himself/goss-installation-action@v1.0.4
+      uses: e1himself/goss-installation-action@v1.2.1
       with:
         version: 'v0.3.16'
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Build the Docker image
-      uses: docker/build-push-action@v3.2.0
+      uses: docker/build-push-action@v6
       with:
         push: false
         tags: phanan/koel:test
+        load: true
     - name: Run goss tests on the image
       shell: bash
       run: dgoss run phanan/koel:test

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -4,13 +4,13 @@ runs:
   using: 'composite'
   steps:
     - name: Install goss and dgoss
-      uses: e1himself/goss-installation-action@v1.2.1
+      uses: e1himself/goss-installation-action@v1.3.0
       with:
         version: 'v0.3.16'
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
     - name: Build the Docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         push: false
         tags: phanan/koel:test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run tests
         uses: ./.github/actions/test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run tests
         uses: ./.github/actions/test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run tests
         uses: ./.github/actions/test
 
@@ -22,19 +22,19 @@ jobs:
     needs: [test]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         id: qemu
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
 
       - name: Set up Docker Build
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -44,7 +44,7 @@ jobs:
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push the production image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           tags: phanan/koel:latest,phanan/koel:${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run tests
         uses: ./.github/actions/test
 
@@ -22,19 +22,19 @@ jobs:
     needs: [test]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.1.0
+        uses: docker/setup-qemu-action@v3
         id: qemu
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
 
       - name: Set up Docker Build
-        uses: docker/setup-buildx-action@v2.2.1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -44,7 +44,7 @@ jobs:
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push the production image
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@v6
         with:
           push: true
           tags: phanan/koel:latest,phanan/koel:${{ steps.version.outputs.VERSION }}


### PR DESCRIPTION
The release workflow's run output is currently noisy with Node 20 deprecation warnings — GitHub is removing Node 20 from runners by September 2026 and forcing the default to Node 24 in June 2026. All the action versions we're pinned to ship Node 20 binaries.

Bumping every action to its current major:

| action | from | to |
|---|---|---|
| `actions/checkout` | `v3` | `v4` |
| `docker/setup-qemu-action` | `v2.1.0` | `v3` |
| `docker/setup-buildx-action` | `v2.2.1` | `v3` |
| `docker/login-action` | `v2.1.0` | `v3` |
| `docker/build-push-action` | `v3.2.0` | `v6` |
| `e1himself/goss-installation-action` | `v1.0.4` | `v1.2.1` |

## Composite test action

`build-push-action@v6` strictly requires `setup-buildx-action` to have run first. The test composite action wasn't setting it up (the original `v3.2.0` had a softer fallback). Two adjustments:

- Added `docker/setup-buildx-action@v3` step before the build.
- Set `load: true` on the build-push-action call so the resulting image is available to the local Docker daemon — without this, buildx builds but doesn't load, and the subsequent `dgoss run phanan/koel:test` would fail with "image not found."

## Test plan

- [ ] CI on this PR (the `Continuous integration` workflow runs on PRs) exercises the test action — green confirms the buildx + load: true wiring works end-to-end.
- After merge, the next release tag should produce a clean run with no deprecation warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated GitHub Actions dependencies across CI/CD workflows to latest versions
  * Upgraded Docker build infrastructure and multi-architecture support tooling
  * Enhanced Docker image build configuration for improved performance
  * Updated testing framework infrastructure with latest compatible versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->