### PR TITLE
fix: align image storage with koel/koel#2479 + allow Apache to follow symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Since this docker image only has one tag which is `latest`, there are no versions. However we'll write changes with the date at which they occured.
 
+## 2026-05-22
+### Fixed
+- ⚠ Image storage path moved to follow koel/koel#2479. If you're upgrading from a previous release, update your `docker-compose.yml` so the `image_storage` volume binds to `/var/www/html/storage/app/public/images` instead of `/var/www/html/public/img/storage`. Existing data in your `image_storage` volume / host bind transfers over automatically when you switch the mount point — files inside the volume don't move, only the mount path inside the container does.
+- Apache now follows symlinks under the document root, fixing the `Symbolic link not allowed or link target not accessible: /var/www/html/public/storage` error introduced when the new image path was symlinked.
+
 ## 2022-04-15
 ### Changed
 - ⚠ BREAKING CHANGE: Image name has changed, it is now [`phanan/koel`](https://hub.docker.com/r/phanan/koel) instead of `hyzual/koel`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Since this docker image only has one tag which is `latest`, there are no version
 - ⚠ Image storage path moved to follow koel/koel#2479. If you're upgrading from a previous release, update your `docker-compose.yml` so the `image_storage` volume binds to `/var/www/html/storage/app/public/images` instead of `/var/www/html/public/img/storage`. Existing data in your `image_storage` volume / host bind transfers over automatically when you switch the mount point — files inside the volume don't move, only the mount path inside the container does.
 - Apache now follows symlinks under the document root, fixing the `Symbolic link not allowed or link target not accessible: /var/www/html/public/storage` error introduced when the new image path was symlinked.
 
+> ⚠ **Heads-up if you already upgraded to a 9.3.x image before this fix.** koel/koel's `koel:init` ran a one-time `migrateLegacyImages` step that *moved* files (destructive) from `public/img/storage/` into the in-container `storage/app/public/images/`. On Docker that target was ephemeral, so the files were wiped on the next image pull and your `image_storage` volume / host bind is now empty. There's nothing this fix can do to recover that — restore from backup if you have one, or let koel re-fetch album / artist art from your source media on the next scan.
+
 ## 2022-04-15
 ### Changed
 - ⚠ BREAKING CHANGE: Image name has changed, it is now [`phanan/koel`](https://hub.docker.com/r/phanan/koel) instead of `hyzual/koel`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,9 @@ RUN apt-get update \
   # Create the search-indexes volume so it has the correct permissions
   && mkdir -p /var/www/html/storage/search-indexes \
   && chown www-data:www-data /var/www/html/storage/search-indexes \
+  # Same for the image storage volume
+  && mkdir -p /var/www/html/storage/app/public/images \
+  && chown -R www-data:www-data /var/www/html/storage/app \
   # Set locale to prevent removal of non-ASCII path characters when transcoding with ffmpeg
   # See https://github.com/koel/docker/pull/91
   && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,7 @@ RUN cp -R /tmp/koel/. /var/www/html \
 # This declaration must be AFTER creating the folders and setting their permissions
 # and AFTER changing to non-root user.
 # Otherwise, they are owned by root and the user cannot write to them.
-VOLUME ["/music", "/var/www/html/public/img/storage", "/var/www/html/storage/search-indexes"]
+VOLUME ["/music", "/var/www/html/storage/app/public/images", "/var/www/html/storage/search-indexes"]
 
 RUN cd /var/www/html \
   && php artisan route:cache \

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ docker exec --user www-data <koel_container> php artisan koel:sync
 | Path | Description |
 |---|---|
 | `/music` | Your music library. |
-| `/var/www/html/public/img/storage` | Uploaded images (album art, user avatars, etc.). |
+| `/var/www/html/storage/app/public/images` | Uploaded images (album art, user avatars, etc.). |
 | `/var/www/html/storage/search-indexes` | Search indexes for songs, albums, and artists. |
 
 ## Ports

--- a/apache.conf
+++ b/apache.conf
@@ -11,6 +11,12 @@
     ServerAdmin webmaster@localhost
     DocumentRoot /var/www/html/public
 
+    <Directory /var/www/html/public>
+        Options +FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+
     # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
     # error, crit, alert, emerg.
     # It is also possible to configure the loglevel for particular

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,7 +17,7 @@ services:
       - DB_PASSWORD=password
     volumes:
       - music:/music
-      - image_storage:/var/www/html/public/img/storage
+      - image_storage:/var/www/html/storage/app/public/images
       - search_index:/var/www/html/storage/search-indexes
       - ./.env.koel:/var/www/html/.env
       - ./sql:/docker-entrypoint-initdb.d

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -13,7 +13,7 @@ services:
       - DB_DATABASE=koel
     volumes:
       - music:/music
-      - image_storage:/var/www/html/public/img/storage
+      - image_storage:/var/www/html/storage/app/public/images
       - search_index:/var/www/html/storage/search-indexes
       - ./sql:/docker-entrypoint-initdb.d
 

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -14,7 +14,7 @@ services:
       - DB_DATABASE=koel
     volumes:
       - music:/music
-      - image_storage:/var/www/html/public/img/storage
+      - image_storage:/var/www/html/storage/app/public/images
       - search_index:/var/www/html/storage/search-indexes
 
   database:


### PR DESCRIPTION
## Summary

Fixes [#220](https://github.com/koel/docker/issues/220). koel/koel#2479 (v9.3.0) relocated user-uploaded images from `public/img/storage/` to `storage/app/public/images/` and exposed them via a symlink at `public/storage/`. The koel/docker image and compose files weren't updated to match, so:

1. Apache 2.4's default `Options -SymLinksIfOwnerMatch` rejected the new symlink — `Symbolic link not allowed or link target not accessible: /var/www/html/public/storage` (the 403 in the report).
2. The `image_storage` named volume was still bound to the old location. The new location (`storage/app/public/images`) was an ephemeral path inside the container, so it got wiped on each image pull. Users who upgraded 9.2 → 9.3 saw images work until the next container restart, then lost everything.

## Changes

- `apache.conf`: added a `<Directory /var/www/html/public>` block with `Options +FollowSymLinks`.
- `Dockerfile`: `VOLUME` line now declares `/var/www/html/storage/app/public/images` (instead of the old `public/img/storage`). Anonymous-volume users get persistence at the new location by default.
- `docker-compose.{mysql,postgres,dev}.yml`: `image_storage` volume now binds to the new path.
- `README.md`: updated the volume table.
- `CHANGELOG.md`: upgrade note.

## Migration story

The named volume's *contents* persist regardless of mount point. If a user just edits their `docker-compose.yml` to change the bind path from `/var/www/html/public/img/storage` → `/var/www/html/storage/app/public/images`, their existing image files appear at the new location automatically. No file copying needed.

Users who already upgraded to 9.3.x and lost data (the report's case) will need to restore from backup — there's nothing in this PR that can recover ephemeral-container data that was already wiped on a previous pull.

## Test plan

- [ ] Build the image locally, run with the updated `docker-compose.postgres.yml`, verify images load (no 403, no missing files).
- [ ] Upgrade scenario: tag an existing volume from the old compose, swap the compose binding, restart container, verify images load.
- [ ] CI green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Uploaded images now persist and are served correctly after deployment.
  * Resolved webserver symlink errors so public assets are accessible.

* **Documentation**
  * Updated deployment docs to reflect the corrected image storage configuration.

* **Note**
  * If you previously upgraded to an older interim image, some files may have been moved into a transient location—you may need to restore or re-fetch missing images.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/docker/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->