### PR TITLE
ci: allow workflow_dispatch on the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,7 @@ jobs:
 
       - name: Resolve version
         id: version
-        # Pass template values through `env:` rather than expanding into the shell script directly,
-        # so a malicious dispatch input can't inject commands. $GITHUB_REF_NAME is already in the
-        # runner's environment by default; only KOEL_VERSION needs explicit binding here.
+        # env-var indirection to prevent template injection from the dispatch input
         env:
           KOEL_VERSION: ${{ inputs.koel_version }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ on:
   push:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  workflow_dispatch:
+    inputs:
+      koel_version:
+        description: 'Koel release tag to build against (e.g. v9.4.0). Required when triggered manually.'
+        required: true
+        type: string
 
 permissions: read-all
 
@@ -39,9 +45,13 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
-      - name: Get version from tag
+      - name: Resolve version
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        # Use the dispatch input when triggered manually; fall back to the pushed tag name.
+        run: |
+          REF="${{ inputs.koel_version || github.ref_name }}"
+          echo "VERSION=${REF#v}" >> "$GITHUB_OUTPUT"
+          echo "TAG=${REF}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push the production image
         uses: docker/build-push-action@v7
@@ -49,3 +59,5 @@ jobs:
           push: true
           tags: phanan/koel:latest,phanan/koel:${{ steps.version.outputs.VERSION }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
+          build-args: |
+            KOEL_VERSION_REF=${{ steps.version.outputs.TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,13 @@ jobs:
 
       - name: Resolve version
         id: version
-        # Use the dispatch input when triggered manually; fall back to the pushed tag name.
+        # Pass template values through `env:` rather than expanding into the shell script directly,
+        # so a malicious dispatch input can't inject commands. $GITHUB_REF_NAME is already in the
+        # runner's environment by default; only KOEL_VERSION needs explicit binding here.
+        env:
+          KOEL_VERSION: ${{ inputs.koel_version }}
         run: |
-          REF="${{ inputs.koel_version || github.ref_name }}"
+          REF="${KOEL_VERSION:-$GITHUB_REF_NAME}"
           echo "VERSION=${REF#v}" >> "$GITHUB_OUTPUT"
           echo "TAG=${REF}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Mirrors what koel/franken's release workflow already does: accept a `koel_version` input via `workflow_dispatch` so a release build can be re-triggered against any Koel tag without pushing a fresh git tag.

Why it matters: today, if the production image build fails (network blip, draft koel/koel release not yet published, etc.), the only recovery path is `gh run rerun <id>` against the original failed run — which only works while the run is still in retention. After 90 days, the run vanishes and the only recourse is to push a phantom git tag.

With this in place, recovery is `gh workflow run release.yml --repo koel/docker -f koel_version=vX.Y.Z`.

## Implementation

- `workflow_dispatch` with a required `koel_version` input
- `Resolve version` step picks `inputs.koel_version` when present, otherwise `github.ref_name` (preserves existing tag-push behavior exactly)
- `build-args: KOEL_VERSION_REF=...` is now passed through to `docker build`, so the workflow value wins over the Dockerfile's `ARG` default. For tag-push runs the two values are identical; for dispatch runs the Dockerfile's pinned version is overridden.

## Test plan

- [ ] Tag-push behavior: next release via `./release vX.Y.Z` still works as before
- [ ] Dispatch behavior: `gh workflow run release.yml -f koel_version=v9.4.0` re-builds v9.4.0 cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now supports manual version entry when triggering a release, with automatic fallback to the current ref when omitted.
  * Resolved release version and tag are emitted and propagated to deployment steps.
  * Docker image builds receive the resolved release tag as a build argument while published image tags remain version-only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/docker/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->