### PR TITLE
Update docker-compose.postgres.yml

### DIFF
--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -14,7 +14,7 @@ services:
       - DB_DATABASE=koel
     volumes:
       - music:/music
-      - image_storage:/var/www/html/storage/app/public/images
+      - image_storage:/var/www/html/public/storage/images
       - search_index:/var/www/html/storage/search-indexes
 
   database:


### PR DESCRIPTION
Corrected path in container to match what Koel is expecting as mountpoint:
koel:doctor
```Image storage directory public/storage/images is not readable/writable  ERROR```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image storage path configuration to ensure correct volume mounting for containerized deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->