### PR TITLE
Update docker-compose.mysql.yml

### DIFF
--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -13,7 +13,7 @@ services:
       - DB_DATABASE=koel
     volumes:
       - music:/music
-      - image_storage:/var/www/html/storage/app/public/images
+      - image_storage:/var/www/html/public/storage/images
       - search_index:/var/www/html/storage/search-indexes
       - ./sql:/docker-entrypoint-initdb.d
 


### PR DESCRIPTION
Corrected path in container to match what Koel is expecting as mountpoint:
koel:doctor
```Image storage directory public/storage/images is not readable/writable  ERROR```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image storage directory configuration to optimize file organization and serving within the application environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->