### PR TITLE
ci: build release images on tag push only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,6 @@ on:
   push:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
-  workflow_dispatch:
-    inputs:
-      koel_version:
-        description: 'Koel release tag to build against (e.g. v9.4.0). Required when triggered manually.'
-        required: true
-        type: string
 
 permissions: read-all
 
@@ -47,11 +41,8 @@ jobs:
 
       - name: Resolve version
         id: version
-        # env-var indirection to prevent template injection from the dispatch input
-        env:
-          KOEL_VERSION: ${{ inputs.koel_version }}
         run: |
-          REF="${KOEL_VERSION:-$GITHUB_REF_NAME}"
+          REF="$GITHUB_REF_NAME"
           echo "VERSION=${REF#v}" >> "$GITHUB_OUTPUT"
           echo "TAG=${REF}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## What

Remove the `workflow_dispatch` trigger (and its `koel_version` input) from the release workflow, so release images are built **only** on a pushed `v*` tag.

## Why

The manual dispatch path built and pushed images against an arbitrary `koel_version` without going through the `./release` script — meaning it never bumped `ARG KOEL_VERSION_REF` in the `Dockerfile` / the `goss.yaml` version, never tagged the repo `vX.Y.Z`, and never moved `latest`. The result was an image build with no corresponding repo release: source stuck on an old version, no tag, stale `latest`.

Making tag-push the only trigger forces every release through `./release vX.Y.Z`, which performs the version bump + tag + `latest` move and then triggers the build via the tag push. One path, always complete.

## Changes

- Drop `workflow_dispatch` and the `koel_version` input from `on:`.
- Simplify the "Resolve version" step to read `$GITHUB_REF_NAME` directly (the env-var indirection existed only to guard the dispatch input against template injection; with tag-push only, the ref is trusted).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release automation now runs only when a version tag is pushed.
  * Removed the option to start the release process manually with a version input.
  * Release version values are now taken directly from the tag name, simplifying how releases are identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->