### PR TITLE
repair the public/storage symlink shipped in the release tarball

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,10 @@ RUN a2enmod rewrite
 # Copy the downloaded release
 RUN cp -R /tmp/koel/. /var/www/html \
   && mv /var/www/html/public/manifest.json.example /var/www/html/public/manifest.json \
+  # The release tarball ships public/storage as an absolute symlink into the path the
+  # release runner built it at, which resolves nowhere here and leaves koel unable to read
+  # or write uploaded images. Replace it with a relative link to the same target.
+  && ln -sfn ../storage/app/public /var/www/html/public/storage \
   && chown -R www-data:www-data /var/www/html
 
 # Volumes for the music files, image storage, and search index

--- a/goss.yaml
+++ b/goss.yaml
@@ -84,6 +84,16 @@ file:
     owner: www-data
     group: www-data
     filetype: directory
+  /var/www/html/storage/app/public/images:
+    exists: true
+    mode: "0755"
+    owner: www-data
+    group: www-data
+    filetype: directory
+  /var/www/html/public/storage:
+    exists: true
+    filetype: symlink
+    linked-to: ../storage/app/public
 package:
   ffmpeg:
     installed: true


### PR DESCRIPTION
Fixes the image storage failure reported in #224, at a different layer than that PR proposed.

### The bug

koel's release archive ships `public/storage` as an **absolute** symlink into the directory the release runner built in. Straight from the v9.11.1 tarball:

```
koel/public/storage -> /home/runner/work/koel/koel/storage/app/public
```

That path exists on no machine but the GitHub Actions runner, so in the container the link dangles. koel resolves uploaded images through `public_path('storage/images')`, so it can neither read nor write them, and `koel:doctor` reports:

```
Image storage directory public/storage/images is not readable/writable  ERROR
```

Confirmed in the currently published image:

```
$ docker run --rm --entrypoint sh phanan/koel:9.11.1 -c 'ls -la /var/www/html/public/storage'
lrwxrwxrwx 1 www-data www-data 46 /var/www/html/public/storage -> /home/runner/work/koel/koel/storage/app/public
```

`koel:init` cannot repair it. Laravel's `storage:link` checks `file_exists()`, which is false for a dangling symlink, so it attempts to create one and fails on the path that is already there.

### The fix

Replace the link at build time with a relative one to the same target, so it resolves wherever the tree is unpacked. The volume stays where the `VOLUME` declaration already points, so existing installations keep their images.

```
$ docker run --rm koel-symlink-test sh -c 'readlink -f /var/www/html/public/storage'
/var/www/html/storage/app/public
```

...and `public/storage/images` is writable by `www-data`, which is what `koel:doctor` checks.

The goss suite now asserts the symlink and its target directory, so a regression fails CI rather than reaching users.

### On #224

That PR moved the volume mount to `public/storage/images` in `docker-compose.mysql.yml`, which does make the path writable, but mounts over the symlink's location — leaving the `VOLUME` declaration pointing at an orphaned path, moving existing installations' images to a different volume, and patching one of the three compose files. Fixing the link in the image covers every compose file and every hand-rolled `docker run`.

The root cause is in koel itself and is fixed separately in koel/koel#2644 — `koel:init` now creates a relative link, so future releases ship a portable archive. This change is still worth keeping: it repairs every release already published.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed broken public storage links in deployed Docker images.
  * Ensured uploaded images are accessible through the application’s public storage path.

* **Tests**
  * Added deployment checks verifying the storage directory permissions, ownership, and symlink target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->